### PR TITLE
Improve README configuration example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -18,6 +18,13 @@ Queue connections and queue pairs are configured in the `MQBridge` section of *a
         "Channel": "SVRCONN.CHANNEL",
         "UserId": "user1",
         "Password": "pwd1"
+      },
+      "ConnB": {
+        "QueueManagerName": "QM2",
+        "ConnectionName": "host2(1414)",
+        "Channel": "SVRCONN.CHANNEL",
+        "UserId": "user2",
+        "Password": "pwd2"
       }
     },
     "QueuePairs": [
@@ -26,6 +33,13 @@ Queue connections and queue pairs are configured in the `MQBridge` section of *a
         "InboundQueue": "IN.Q1",
         "OutboundConnection": "ConnB",
         "OutboundQueue": "OUT.Q1",
+        "PollIntervalSeconds": 30
+      },
+      {
+        "InboundConnection": "ConnB",
+        "InboundQueue": "IN.Q2",
+        "OutboundConnection": "ConnA",
+        "OutboundQueue": "OUT.Q2",
         "PollIntervalSeconds": 30
       }
     ]


### PR DESCRIPTION
## Summary
- show two connections and two queue pairs in README

## Testing
- `dotnet test Tix.IBMMQ.Bridge.sln --verbosity normal` *(fails: unable to restore packages)*

------
https://chatgpt.com/codex/tasks/task_e_68761ba3d7c48323b4880b8376589052