### PR TITLE
Add integration tests with Testcontainers

### DIFF
--- a/Tix.IBMMQ.Bridge.IntegrationTests/Services/MQBridgeIntegrationTests.cs
+++ b/Tix.IBMMQ.Bridge.IntegrationTests/Services/MQBridgeIntegrationTests.cs
@@ -1,0 +1,125 @@
+using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Configurations;
+using DotNet.Testcontainers.Containers;
+using IBM.WMQ;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using System.Collections;
+using Tix.IBMMQ.Bridge.Options;
+using Tix.IBMMQ.Bridge.Services;
+using Xunit;
+
+namespace Tix.IBMMQ.Bridge.IntegrationTests.Services;
+
+public class MQBridgeIntegrationTests : IAsyncLifetime
+{
+    private readonly TestcontainersContainer _container;
+
+    public MQBridgeIntegrationTests()
+    {
+        _container = new TestcontainersBuilder<TestcontainersContainer>()
+            .WithImage("icr.io/ibm-messaging/mq:latest")
+            .WithEnvironment("LICENSE", "accept")
+            .WithEnvironment("MQ_QMGR_NAME", "QM1")
+            .WithEnvironment("MQ_APP_PASSWORD", "passw0rd")
+            .WithExposedPort(1414)
+            .WithWaitStrategy(Wait.ForUnixContainer().UntilPortIsAvailable(1414))
+            .Build();
+    }
+
+    public async Task InitializeAsync() => await _container.StartAsync();
+
+    public async Task DisposeAsync() => await _container.DisposeAsync();
+
+    [Fact]
+    public async Task Should_forward_message_between_queues()
+    {
+        var port = _container.GetMappedPublicPort(1414);
+        var conn = new ConnectionOptions
+        {
+            QueueManagerName = "QM1",
+            ConnectionName = $"localhost({port})",
+            Channel = "DEV.APP.SVRCONN",
+            UserId = "app",
+            Password = "passw0rd"
+        };
+
+        var options = new MQBridgeOptions
+        {
+            Connections =
+            {
+                ["ConnA"] = conn,
+                ["ConnB"] = conn
+            },
+            QueuePairs =
+            {
+                new QueuePairOptions
+                {
+                    InboundConnection = "ConnA",
+                    InboundQueue = "DEV.QUEUE.1",
+                    OutboundConnection = "ConnB",
+                    OutboundQueue = "DEV.QUEUE.2",
+                    PollIntervalSeconds = 1
+                }
+            }
+        };
+
+        PutMessage(conn, "DEV.QUEUE.1", "hello");
+
+        using var host = Host.CreateDefaultBuilder()
+            .ConfigureServices(s =>
+            {
+                s.AddLogging();
+                s.AddSingleton<IHostedService, MQBridgeService>();
+                s.Configure<MQBridgeOptions>(opts =>
+                {
+                    opts.Connections = options.Connections;
+                    opts.QueuePairs = options.QueuePairs;
+                });
+            })
+            .Build();
+
+        await host.StartAsync();
+        await Task.Delay(2000);
+        await host.StopAsync();
+
+        var message = GetMessage(conn, "DEV.QUEUE.2");
+        message.ShouldBe("hello");
+    }
+
+    private static void PutMessage(ConnectionOptions conn, string queueName, string message)
+    {
+        var props = BuildProperties(conn);
+        using var qMgr = new MQQueueManager(conn.QueueManagerName, props);
+        using var queue = qMgr.AccessQueue(queueName, MQC.MQOO_OUTPUT | MQC.MQOO_FAIL_IF_QUIESCING);
+        var mqMessage = new MQMessage();
+        mqMessage.WriteString(message);
+        queue.Put(mqMessage, new MQPutMessageOptions { Options = MQC.MQPMO_SYNCPOINT });
+        qMgr.Commit();
+    }
+
+    private static string GetMessage(ConnectionOptions conn, string queueName)
+    {
+        var props = BuildProperties(conn);
+        using var qMgr = new MQQueueManager(conn.QueueManagerName, props);
+        using var queue = qMgr.AccessQueue(queueName, MQC.MQOO_INPUT_AS_Q_DEF | MQC.MQOO_FAIL_IF_QUIESCING);
+        var msg = new MQMessage();
+        queue.Get(msg, new MQGetMessageOptions { Options = MQC.MQGMO_NO_WAIT });
+        return msg.ReadString(msg.DataLength);
+    }
+
+    private static Hashtable BuildProperties(ConnectionOptions opts)
+    {
+        var (host, port) = MQBridgeService.ParseConnectionName(opts.ConnectionName);
+        return new Hashtable
+        {
+            { MQC.HOST_NAME_PROPERTY, host },
+            { MQC.PORT_PROPERTY, port },
+            { MQC.CHANNEL_PROPERTY, opts.Channel },
+            { MQC.USER_ID_PROPERTY, opts.UserId },
+            { MQC.PASSWORD_PROPERTY, opts.Password },
+            { MQC.TRANSPORT_PROPERTY, MQC.TRANSPORT_MQSERIES_MANAGED }
+        };
+    }
+}

--- a/Tix.IBMMQ.Bridge.IntegrationTests/Tix.IBMMQ.Bridge.IntegrationTests.csproj
+++ b/Tix.IBMMQ.Bridge.IntegrationTests/Tix.IBMMQ.Bridge.IntegrationTests.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0" />
+    <PackageReference Include="Shouldly" Version="5.0.0" />
+    <PackageReference Include="DotNet.Testcontainers" Version="3.7.0" />
+    <PackageReference Include="IBM.WMQ.ManagedClient" Version="9.4.0.0" />
+    <ProjectReference Include="..\Tix.IBMMQ.Bridge\Tix.IBMMQ.Bridge.csproj" />
+  </ItemGroup>
+</Project>

--- a/Tix.IBMMQ.Bridge.sln
+++ b/Tix.IBMMQ.Bridge.sln
@@ -6,6 +6,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tix.IBMMQ.Bridge", "Tix.IBM
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tix.IBMMQ.Bridge.Tests", "Tix.IBMMQ.Bridge.Tests/Tix.IBMMQ.Bridge.Tests.csproj", "{9627f076-7197-40db-a072-f355b7221f59}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tix.IBMMQ.Bridge.IntegrationTests", "Tix.IBMMQ.Bridge.IntegrationTests/Tix.IBMMQ.Bridge.IntegrationTests.csproj", "{226357b9-9487-42b3-9e61-8889fab3483f}"
+EndProject
 Global
 GlobalSection(SolutionConfigurationPlatforms) = preSolution
 Debug|Any CPU = Debug|Any CPU
@@ -20,5 +22,9 @@ GlobalSection(ProjectConfigurationPlatforms) = postSolution
 {9627f076-7197-40db-a072-f355b7221f59}.Debug|Any CPU.Build.0 = Debug|Any CPU
 {9627f076-7197-40db-a072-f355b7221f59}.Release|Any CPU.ActiveCfg = Release|Any CPU
 {9627f076-7197-40db-a072-f355b7221f59}.Release|Any CPU.Build.0 = Release|Any CPU
+{226357b9-9487-42b3-9e61-8889fab3483f}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{226357b9-9487-42b3-9e61-8889fab3483f}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{226357b9-9487-42b3-9e61-8889fab3483f}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{226357b9-9487-42b3-9e61-8889fab3483f}.Release|Any CPU.Build.0 = Release|Any CPU
 EndGlobalSection
 EndGlobal


### PR DESCRIPTION
## Summary
- add new integration test project
- test bridging with a real IBM MQ container using Testcontainers

## Testing
- `dotnet test Tix.IBMMQ.Bridge.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68761d3c9d288323ba10974b8212f1bb