### PR TITLE
Switch to IBMMQDotnetClient

### DIFF
--- a/Tix.IBMMQ.Bridge.Tests/Tix.IBMMQ.Bridge.Tests.csproj
+++ b/Tix.IBMMQ.Bridge.Tests/Tix.IBMMQ.Bridge.Tests.csproj
@@ -8,7 +8,7 @@
     <PackageReference Include="xunit" Version="2.5.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0" />
     <PackageReference Include="Shouldly" Version="5.0.0" />
-    <PackageReference Include="IBM.WMQ.ManagedClient" Version="9.4.0.0" />
+    <PackageReference Include="IBMMQDotnetClient" Version="9.4.3" />
     <ProjectReference Include="..\Tix.IBMMQ.Bridge\Tix.IBMMQ.Bridge.csproj" />
     <None Include="..\Tix.IBMMQ.Bridge\appsettings.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>

--- a/Tix.IBMMQ.Bridge/Tix.IBMMQ.Bridge.csproj
+++ b/Tix.IBMMQ.Bridge/Tix.IBMMQ.Bridge.csproj
@@ -3,6 +3,6 @@
     <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IBM.WMQ.ManagedClient" Version="9.4.0.0" />
+    <PackageReference Include="IBMMQDotnetClient" Version="9.4.3" />
   </ItemGroup>
 </Project>

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # Tix.IBMMQ.Bridge
 
-This project is an ASP.NET Core 8.0 service that acts as a bridge between multiple IBM MQ servers using the managed client driver.
+This project is an ASP.NET Core 8.0 service that acts as a bridge between multiple IBM MQ servers using the IBMMQDotnetClient library.
 
 The bridge reads messages under *syncpoint* and only commits them after they have been forwarded. If an error occurs while writing to the outbound queue the read is rolled back, ensuring that no messages are lost.
 


### PR DESCRIPTION
## Summary
- use `IBMMQDotnetClient` instead of the older managed client
- update README to reflect the new library

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68761f008d608323afade9f5d520fc6d