### PR TITLE
Fix build errors

### DIFF
--- a/Tix.IBMMQ.Bridge.IntegrationTests/Services/MQBridgeIntegrationTests.cs
+++ b/Tix.IBMMQ.Bridge.IntegrationTests/Services/MQBridgeIntegrationTests.cs
@@ -6,6 +6,8 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Shouldly;
 using System.Collections;
+using System.Threading.Tasks;
+using System.Threading;
 using Tix.IBMMQ.Bridge.Options;
 using Tix.IBMMQ.Bridge.Services;
 using Xunit;

--- a/Tix.IBMMQ.Bridge.IntegrationTests/Tix.IBMMQ.Bridge.IntegrationTests.csproj
+++ b/Tix.IBMMQ.Bridge.IntegrationTests/Tix.IBMMQ.Bridge.IntegrationTests.csproj
@@ -7,9 +7,9 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="xunit" Version="2.5.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0" />
-    <PackageReference Include="Shouldly" Version="5.0.0" />
-    <PackageReference Include="DotNet.Testcontainers" Version="3.7.0" />
-    <PackageReference Include="IBM.WMQ.ManagedClient" Version="9.4.0.0" />
+    <PackageReference Include="Shouldly" Version="4.3.0" />
+    <PackageReference Include="DotNet.Testcontainers" Version="1.6.0" />
+    <PackageReference Include="IBMMQDotnetClient" Version="9.4.3" />
     <ProjectReference Include="..\Tix.IBMMQ.Bridge\Tix.IBMMQ.Bridge.csproj" />
   </ItemGroup>
 </Project>

--- a/Tix.IBMMQ.Bridge.Tests/Tix.IBMMQ.Bridge.Tests.csproj
+++ b/Tix.IBMMQ.Bridge.Tests/Tix.IBMMQ.Bridge.Tests.csproj
@@ -7,7 +7,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="xunit" Version="2.5.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0" />
-    <PackageReference Include="Shouldly" Version="5.0.0" />
+    <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="IBMMQDotnetClient" Version="9.4.3" />
     <ProjectReference Include="..\Tix.IBMMQ.Bridge\Tix.IBMMQ.Bridge.csproj" />
     <None Include="..\Tix.IBMMQ.Bridge\appsettings.json" CopyToOutputDirectory="PreserveNewest" />

--- a/Tix.IBMMQ.Bridge/Program.cs
+++ b/Tix.IBMMQ.Bridge/Program.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.AspNetCore.Builder;
 using Tix.IBMMQ.Bridge.Options;
 using Tix.IBMMQ.Bridge.Services;
 

--- a/Tix.IBMMQ.Bridge/Services/MQBridgeService.cs
+++ b/Tix.IBMMQ.Bridge/Services/MQBridgeService.cs
@@ -3,6 +3,10 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using System.Collections;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Linq;
 using Tix.IBMMQ.Bridge.Options;
 
 namespace Tix.IBMMQ.Bridge.Services;
@@ -92,7 +96,7 @@ public class MQBridgeService : BackgroundService
         };
     }
 
-    internal static (string host, int port) ParseConnectionName(string connectionName)
+    public static (string host, int port) ParseConnectionName(string connectionName)
     {
         var start = connectionName.IndexOf('(');
         var end = connectionName.IndexOf(')', start + 1);


### PR DESCRIPTION
## Summary
- fix build by referencing available package versions
- expose `ParseConnectionName` publicly
- add missing using directives

## Testing
- `dotnet build Tix.IBMMQ.Bridge.sln -c Release`
- `dotnet test Tix.IBMMQ.Bridge.sln -c Release --no-build` *(fails: System.Net.Http.HttpRequestException)*

------
https://chatgpt.com/codex/tasks/task_e_68762141b5348323a916ad3014776c1d