### PR TITLE
Move channel config to queue pairs

### DIFF
--- a/Tix.IBMMQ.Bridge.IntegrationTests/Services/MQBridgeIntegrationTests.cs
+++ b/Tix.IBMMQ.Bridge.IntegrationTests/Services/MQBridgeIntegrationTests.cs
@@ -38,11 +38,11 @@ public class MQBridgeIntegrationTests : IAsyncLifetime
     public async Task Should_forward_message_between_queues()
     {
         var port = _container.GetMappedPublicPort(1414);
+        const string channel = "DEV.APP.SVRCONN";
         var conn = new ConnectionOptions
         {
             QueueManagerName = "QM1",
             ConnectionName = $"localhost({port})",
-            Channel = "DEV.APP.SVRCONN",
             UserId = "app",
             Password = "passw0rd"
         };
@@ -59,15 +59,17 @@ public class MQBridgeIntegrationTests : IAsyncLifetime
                 new QueuePairOptions
                 {
                     InboundConnection = "ConnA",
+                    InboundChannel = channel,
                     InboundQueue = "DEV.QUEUE.1",
                     OutboundConnection = "ConnB",
+                    OutboundChannel = channel,
                     OutboundQueue = "DEV.QUEUE.2",
                     PollIntervalSeconds = 1
                 }
             }
         };
 
-        PutMessage(conn, "DEV.QUEUE.1", "hello");
+        PutMessage(conn, channel, "DEV.QUEUE.1", "hello");
 
         using var host = Host.CreateDefaultBuilder()
             .ConfigureServices(s =>
@@ -86,13 +88,13 @@ public class MQBridgeIntegrationTests : IAsyncLifetime
         await Task.Delay(2000);
         await host.StopAsync();
 
-        var message = GetMessage(conn, "DEV.QUEUE.2");
+        var message = GetMessage(conn, channel, "DEV.QUEUE.2");
         message.ShouldBe("hello");
     }
 
-    private static void PutMessage(ConnectionOptions conn, string queueName, string message)
+    private static void PutMessage(ConnectionOptions conn, string channel, string queueName, string message)
     {
-        var props = BuildProperties(conn);
+        var props = BuildProperties(conn, channel);
         using var qMgr = new MQQueueManager(conn.QueueManagerName, props);
         using var queue = qMgr.AccessQueue(queueName, MQC.MQOO_OUTPUT | MQC.MQOO_FAIL_IF_QUIESCING);
         var mqMessage = new MQMessage();
@@ -101,9 +103,9 @@ public class MQBridgeIntegrationTests : IAsyncLifetime
         qMgr.Commit();
     }
 
-    private static string GetMessage(ConnectionOptions conn, string queueName)
+    private static string GetMessage(ConnectionOptions conn, string channel, string queueName)
     {
-        var props = BuildProperties(conn);
+        var props = BuildProperties(conn, channel);
         using var qMgr = new MQQueueManager(conn.QueueManagerName, props);
         using var queue = qMgr.AccessQueue(queueName, MQC.MQOO_INPUT_AS_Q_DEF | MQC.MQOO_FAIL_IF_QUIESCING);
         var msg = new MQMessage();
@@ -111,14 +113,14 @@ public class MQBridgeIntegrationTests : IAsyncLifetime
         return msg.ReadString(msg.DataLength);
     }
 
-    private static Hashtable BuildProperties(ConnectionOptions opts)
+    private static Hashtable BuildProperties(ConnectionOptions opts, string channel)
     {
         var (host, port) = MQBridgeService.ParseConnectionName(opts.ConnectionName);
         return new Hashtable
         {
             { MQC.HOST_NAME_PROPERTY, host },
             { MQC.PORT_PROPERTY, port },
-            { MQC.CHANNEL_PROPERTY, opts.Channel },
+            { MQC.CHANNEL_PROPERTY, channel },
             { MQC.USER_ID_PROPERTY, opts.UserId },
             { MQC.PASSWORD_PROPERTY, opts.Password },
             { MQC.TRANSPORT_PROPERTY, MQC.TRANSPORT_MQSERIES_MANAGED }

--- a/Tix.IBMMQ.Bridge.Tests/Options/ConfigurationBindingTests.cs
+++ b/Tix.IBMMQ.Bridge.Tests/Options/ConfigurationBindingTests.cs
@@ -20,5 +20,6 @@ public class ConfigurationBindingTests
         opts!.Connections.ShouldContainKey("ConnA");
         opts.QueuePairs.Count.ShouldBeGreaterThan(0);
         opts.Connections["ConnA"].QueueManagerName.ShouldBe("QM1");
+        opts.QueuePairs[0].InboundChannel.ShouldBe("SVRCONN.CHANNEL");
     }
 }

--- a/Tix.IBMMQ.Bridge/Options/ConnectionOptions.cs
+++ b/Tix.IBMMQ.Bridge/Options/ConnectionOptions.cs
@@ -4,7 +4,6 @@ public class ConnectionOptions
 {
     public string QueueManagerName { get; set; } = string.Empty;
     public string ConnectionName { get; set; } = string.Empty; // host(port)
-    public string Channel { get; set; } = string.Empty;
     public string UserId { get; set; } = string.Empty;
     public string Password { get; set; } = string.Empty;
 }

--- a/Tix.IBMMQ.Bridge/Options/QueuePairOptions.cs
+++ b/Tix.IBMMQ.Bridge/Options/QueuePairOptions.cs
@@ -3,8 +3,10 @@ namespace Tix.IBMMQ.Bridge.Options;
 public class QueuePairOptions
 {
     public string InboundConnection { get; set; } = string.Empty;
+    public string InboundChannel { get; set; } = string.Empty;
     public string InboundQueue { get; set; } = string.Empty;
     public string OutboundConnection { get; set; } = string.Empty;
+    public string OutboundChannel { get; set; } = string.Empty;
     public string OutboundQueue { get; set; } = string.Empty;
     public int PollIntervalSeconds { get; set; }
 }

--- a/Tix.IBMMQ.Bridge/Services/MQBridgeService.cs
+++ b/Tix.IBMMQ.Bridge/Services/MQBridgeService.cs
@@ -37,8 +37,8 @@ public class MQBridgeService : BackgroundService
                 var inbound = _options.Connections[pair.InboundConnection];
                 var outbound = _options.Connections[pair.OutboundConnection];
 
-                using var inboundQMgr = new MQQueueManager(inbound.QueueManagerName, BuildProperties(inbound));
-                using var outboundQMgr = new MQQueueManager(outbound.QueueManagerName, BuildProperties(outbound));
+                using var inboundQMgr = new MQQueueManager(inbound.QueueManagerName, BuildProperties(inbound, pair.InboundChannel));
+                using var outboundQMgr = new MQQueueManager(outbound.QueueManagerName, BuildProperties(outbound, pair.OutboundChannel));
 
                 using var inboundQueue = inboundQMgr.AccessQueue(pair.InboundQueue, MQC.MQOO_INPUT_AS_Q_DEF | MQC.MQOO_FAIL_IF_QUIESCING);
                 using var outboundQueue = outboundQMgr.AccessQueue(pair.OutboundQueue, MQC.MQOO_OUTPUT | MQC.MQOO_FAIL_IF_QUIESCING);
@@ -82,14 +82,14 @@ public class MQBridgeService : BackgroundService
         }
     }
 
-    private Hashtable BuildProperties(ConnectionOptions opts)
+    private Hashtable BuildProperties(ConnectionOptions opts, string channel)
     {
         var (host, port) = ParseConnectionName(opts.ConnectionName);
         return new Hashtable
         {
             { MQC.HOST_NAME_PROPERTY, host },
             { MQC.PORT_PROPERTY, port },
-            { MQC.CHANNEL_PROPERTY, opts.Channel },
+            { MQC.CHANNEL_PROPERTY, channel },
             { MQC.USER_ID_PROPERTY, opts.UserId },
             { MQC.PASSWORD_PROPERTY, opts.Password },
             { MQC.TRANSPORT_PROPERTY, MQC.TRANSPORT_MQSERIES_MANAGED }

--- a/Tix.IBMMQ.Bridge/appsettings.json
+++ b/Tix.IBMMQ.Bridge/appsettings.json
@@ -4,14 +4,12 @@
       "ConnA": {
         "QueueManagerName": "QM1",
         "ConnectionName": "host1(1414)",
-        "Channel": "SVRCONN.CHANNEL",
         "UserId": "user1",
         "Password": "pwd1"
       },
       "ConnB": {
         "QueueManagerName": "QM2",
         "ConnectionName": "host2(1414)",
-        "Channel": "SVRCONN.CHANNEL",
         "UserId": "user2",
         "Password": "pwd2"
       }
@@ -19,14 +17,18 @@
     "QueuePairs": [
       {
         "InboundConnection": "ConnA",
+        "InboundChannel": "SVRCONN.CHANNEL",
         "InboundQueue": "IN.Q1",
         "OutboundConnection": "ConnB",
+        "OutboundChannel": "SVRCONN.CHANNEL",
         "OutboundQueue": "OUT.Q1"
       },
       {
         "InboundConnection": "ConnB",
+        "InboundChannel": "SVRCONN.CHANNEL",
         "InboundQueue": "IN.Q2",
         "OutboundConnection": "ConnA",
+        "OutboundChannel": "SVRCONN.CHANNEL",
         "OutboundQueue": "OUT.Q2"
       }
     ]

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -4,7 +4,12 @@ This document explains how to build, run and test the **Tix.IBMMQ.Bridge** proje
 
 ## Prerequisites
 
-- .NET 8.0 SDK
+- .NET 8.0 SDK. On Ubuntu you can install it with:
+
+  ```bash
+  sudo apt-get install -y dotnet-sdk-8.0
+  ```
+
 - Access to one or more IBM MQ queue managers
 
 ## Build

--- a/readme.md
+++ b/readme.md
@@ -15,14 +15,12 @@ Queue connections and queue pairs are configured in the `MQBridge` section of *a
       "ConnA": {
         "QueueManagerName": "QM1",
         "ConnectionName": "host1(1414)",
-        "Channel": "SVRCONN.CHANNEL",
         "UserId": "user1",
         "Password": "pwd1"
       },
       "ConnB": {
         "QueueManagerName": "QM2",
         "ConnectionName": "host2(1414)",
-        "Channel": "SVRCONN.CHANNEL",
         "UserId": "user2",
         "Password": "pwd2"
       }
@@ -30,14 +28,18 @@ Queue connections and queue pairs are configured in the `MQBridge` section of *a
     "QueuePairs": [
       {
         "InboundConnection": "ConnA",
+        "InboundChannel": "SVRCONN.CHANNEL",
         "InboundQueue": "IN.Q1",
         "OutboundConnection": "ConnB",
+        "OutboundChannel": "SVRCONN.CHANNEL",
         "OutboundQueue": "OUT.Q1"
       },
       {
         "InboundConnection": "ConnB",
+        "InboundChannel": "SVRCONN.CHANNEL",
         "InboundQueue": "IN.Q2",
         "OutboundConnection": "ConnA",
+        "OutboundChannel": "SVRCONN.CHANNEL",
         "OutboundQueue": "OUT.Q2"
       }
     ]


### PR DESCRIPTION
## Summary
- move channel information from connection options to queue pair options
- update service logic and helper methods to use queue pair channels
- adjust tests, sample configuration and docs
- document how to install the .NET SDK on Ubuntu

## Testing
- `dotnet build Tix.IBMMQ.Bridge.sln -c Release`
- `dotnet test Tix.IBMMQ.Bridge.Tests/Tix.IBMMQ.Bridge.Tests.csproj`
- `dotnet test Tix.IBMMQ.Bridge.IntegrationTests/Tix.IBMMQ.Bridge.IntegrationTests.csproj` *(fails: Connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_687742684ac0832388f9c37eab6943d4