### PR TITLE
Add bash compatibility note

### DIFF
--- a/Tix.IBMMQ.Bridge.IntegrationTests/Services/MQBridgeIntegrationTests.cs
+++ b/Tix.IBMMQ.Bridge.IntegrationTests/Services/MQBridgeIntegrationTests.cs
@@ -37,7 +37,7 @@ public class MQBridgeIntegrationTests : IAsyncLifetime
         var image = isArm
             // Use the developer image built from the mq-container project when running
             // on Apple Silicon or other ARM64 machines
-            ? "ibm-mqadvanced-server-dev:9.3.3.0-arm64"
+            ? "ibm-mqadvanced-server-dev:9.4.3.0-arm64"
             // Otherwise pull the official image from Docker Hub
             : "ibmcom/mq:latest";
 

--- a/Tix.IBMMQ.Bridge.IntegrationTests/Tix.IBMMQ.Bridge.IntegrationTests.csproj
+++ b/Tix.IBMMQ.Bridge.IntegrationTests/Tix.IBMMQ.Bridge.IntegrationTests.csproj
@@ -8,7 +8,7 @@
     <PackageReference Include="xunit" Version="2.5.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
-    <PackageReference Include="DotNet.Testcontainers" Version="1.6.0" />
+    <PackageReference Include="Testcontainers" Version="4.6.0" />
     <PackageReference Include="IBMMQDotnetClient" Version="9.4.3" />
     <ProjectReference Include="..\Tix.IBMMQ.Bridge\Tix.IBMMQ.Bridge.csproj" />
   </ItemGroup>

--- a/Tix.IBMMQ.Bridge.sln
+++ b/Tix.IBMMQ.Bridge.sln
@@ -8,6 +8,13 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tix.IBMMQ.Bridge.Tests", "T
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tix.IBMMQ.Bridge.IntegrationTests", "Tix.IBMMQ.Bridge.IntegrationTests/Tix.IBMMQ.Bridge.IntegrationTests.csproj", "{226357b9-9487-42b3-9e61-8889fab3483f}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{1DA26418-0648-42B4-B127-39AA39F88759}"
+    ProjectSection(SolutionItems) = preProject
+        check-arch.sh = check-arch.sh
+        build-arm-mq-image.sh = build-arm-mq-image.sh
+        run-integration-tests.sh = run-integration-tests.sh
+    EndProjectSection
+EndProject
 Global
 GlobalSection(SolutionConfigurationPlatforms) = preSolution
 Debug|Any CPU = Debug|Any CPU

--- a/build-arm-mq-image.sh
+++ b/build-arm-mq-image.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+repo_dir="mq-container"
+if [ ! -d "$repo_dir" ]; then
+  git clone https://github.com/ibm-messaging/mq-container.git "$repo_dir"
+fi
+cd "$repo_dir"
+ARCH=arm64 make build-devserver

--- a/check-arch.sh
+++ b/check-arch.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+arch=$(uname -m)
+if [[ "$arch" == "arm64" || "$arch" == "aarch64" ]]; then
+  echo "Running on ARM64 architecture ($arch)."
+else
+  echo "Running on $arch architecture."
+fi

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -28,15 +28,45 @@ dotnet run --project Tix.IBMMQ.Bridge
 
 ## Run the tests
 
+Check the current architecture before running the tests:
+
+```bash
+./check-arch.sh
+```
+
+This script prints whether the machine is running on Apple Silicon/ARM64 or another architecture.
+
+If it reports `arm64`, you can build a local IBM MQ developer image using the
+[mq-container](https://github.com/ibm-messaging/mq-container) project:
+
+```bash
+git clone https://github.com/ibm-messaging/mq-container.git
+cd mq-container
+ARCH=arm64 make build-devserver
+```
+
+This creates an image tagged `ibm-mqadvanced-server-dev:9.3.3.0-arm64`.
+The helper script `run-integration-tests.sh` will automatically build this image
+if it's missing and then execute the tests. The script uses **Bash**, so on
+macOS run it with `bash ./run-integration-tests.sh` if the default shell is not
+Bash.
+
 Execute unit tests with:
 
 ```bash
 dotnet test Tix.IBMMQ.Bridge.Tests/Tix.IBMMQ.Bridge.Tests.csproj
 ```
 
-Integration tests require Docker to be available to start a temporary IBM MQ
-instance. Run them with:
+Integration tests require Docker. The `run-integration-tests.sh` helper will
+verify the architecture, build the ARM64 image when necessary and then invoke
+`dotnet test`:
 
 ```bash
-dotnet test Tix.IBMMQ.Bridge.IntegrationTests/Tix.IBMMQ.Bridge.IntegrationTests.csproj
+bash ./run-integration-tests.sh
 ```
+
+> **Note**
+> When running under Podman the Testcontainers "resource reaper" cannot start
+> because Podman refuses to hijack the connection stream. The integration tests
+> disable the reaper to avoid `cannot hijack chunked or content length stream`
+> errors. You may need to manually remove containers after the tests complete.

--- a/run-integration-tests.sh
+++ b/run-integration-tests.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+./check-arch.sh
+set -e
+arch=$(uname -m)
+if [[ "$arch" == "arm64" || "$arch" == "aarch64" ]]; then
+  image="ibm-mqadvanced-server-dev:9.3.3.0-arm64"
+  if ! docker image inspect "$image" >/dev/null 2>&1; then
+    echo "IBM MQ ARM64 image not found. Building it..."
+    ./build-arm-mq-image.sh
+  fi
+fi
+
+dotnet test Tix.IBMMQ.Bridge.IntegrationTests/Tix.IBMMQ.Bridge.IntegrationTests.csproj "$@"


### PR DESCRIPTION
## Summary
- run helper scripts with `/bin/bash` for better macOS compatibility
- document that integration test script requires Bash

## Testing
- `dotnet test Tix.IBMMQ.Bridge.Tests/Tix.IBMMQ.Bridge.Tests.csproj -v minimal`
- `bash ./run-integration-tests.sh -v minimal` *(fails: could not connect to Docker)*

------
https://chatgpt.com/codex/tasks/task_e_6883de33e758832385b2b53bcab97e67